### PR TITLE
Added a switch to function ApplyWeaponFOV

### DIFF
--- a/Classes/foxPlayerInput.uc
+++ b/Classes/foxPlayerInput.uc
@@ -27,6 +27,7 @@ var globalconfig float Desired43FOV;
 var globalconfig bool bCorrectZoomFOV;
 var globalconfig bool bCorrectMouseSensitivity;
 var globalconfig float Desired43MouseSensitivity;
+var globalconfig bool bCorrectWeaponFOV;
 
 struct WideHUDMapStruct
 {
@@ -161,6 +162,8 @@ function ApplyWeaponFOV(Weapon Weap)
 {
 	local float ScaleFactor;
 
+	if (default.bCorrectWeaponFOV)
+	{
 	//First reset our "default default" values before doing anything else
 	UpdateCachedWeaponInfo(Weap);
 
@@ -180,6 +183,13 @@ function ApplyWeaponFOV(Weapon Weap)
 		Weap.OldSmallViewOffset = Weap.default.OldSmallViewOffset * ScaleFactor;
 		Weap.bInitOldMesh = true; //Force a ViewOffset update
 	}
+}	
+	
+	else
+	{
+		return;
+	}
+
 }
 function UpdateCachedWeaponInfo(Weapon Weap)
 {
@@ -305,6 +315,7 @@ defaultproperties
 	Desired43FOV=90f
 	bCorrectZoomFOV=true
 	bCorrectMouseSensitivity=true
+	bCorrectWeaponFOV=True
 	Desired43MouseSensitivity=-1f
 	WideHUDMap(0)=(HUDClass=class'HUD_Assault',WideHUD="foxWSFix.foxWideHUD_Assault")
 	WideHUDMap(1)=(HUDClass=class'HudCBombingRun',WideHUD="foxWSFix.foxWideHudCBombingRun")


### PR DESCRIPTION
Added a switch to toggle the ApplyWeaponFOV function on or off due to some weapon mods for UT2004 not playing nice with the way Foxfov changes the weaponFOV.
Ballistic Weapons is 1 of these weapon mods that has some weird effects when the ApplyWeaponFOV function is active. Turning off the ApplyWeaponFOV function restored the guns to there intented positions. 

The switch can be turned on or off via the user.ini and is in the same section where all other settings are stored
When the default property: bCorrectWeaponFOV is set to true the code will execute as normal and change the fov of the weapon, when its set to false it will skip the weaponfov code and simply return not changing the weapon fov.

I've tested it in-game and it works as intended.