### PR TITLE
Fix Bombing Run "Missing Material" error

### DIFF
--- a/Classes/Include/Team/BombingRun/_Internal/ShowTeamScorePassA.uci
+++ b/Classes/Include/Team/BombingRun/_Internal/ShowTeamScorePassA.uci
@@ -22,7 +22,8 @@ simulated function TeamBombingRunWideShowTeamScorePassA(Canvas C)
 
 	DrawSpriteTileWidget (C, BombBG);
 	DrawSpriteTileWidget (C, BombWidget.Widgets[BombWidget.BombState]);
-	DrawSpriteTileWidget (C, BombWidgetStatus.Widgets[BombWidget.BombState]);
+	if ( BombWidgetStatus.Widgets[BombWidget.BombState].WidgetTexture != None ) //Only draw if texture exists ~fox
+		DrawSpriteTileWidget (C, BombWidgetStatus.Widgets[BombWidget.BombState]);
 
 	if ( BombFlag == None )
 		ForEach DynamicActors(Class'xBombFlag', BombFlag)


### PR DESCRIPTION
**Problem:** The mutator threw a "Missing Material" error in Bombing Run when `DrawSpriteTileWidget` tried to render `BombWidgetStatus` for bomb states 0 (FLAG_Home) and 1 (FLAG_HeldFriendly). The `BombWidgetStatus` struct only defines textures for states 2 and 3, leaving states 0 and 1 with null `WidgetTexture` references.

```
Log: foxWideHudCBombingRun BR-Colossus.foxWideHudCBombingRun (Function foxWSFix.foxWideHudCBombingRun.DrawSpriteTileWidget:0262) DrawTile: Missing Material
```

**Fix:** Added a null check before drawing `BombWidgetStatus` to only render when the widget has a valid texture material, matching the pattern used elsewhere in the HUD code.

**Closes** https://github.com/alexstrout/foxWSFix-UT2k4/issues/18

---
*This fix was generated with the help of Claude Sonnet 4.5*
